### PR TITLE
fix: Remove the unnecessary favicon from index.html.ejs template

### DIFF
--- a/templates/index.html.ejs
+++ b/templates/index.html.ejs
@@ -2,7 +2,6 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <% if (data.projectName) { %><title><%= data.projectName %></title><% } else { %><title>Vite + React + TS</title><% } %>
     </head>


### PR DESCRIPTION
# Description

- Removed the unnecessary favicon from `index.html.ejs` template.

# Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Documentation update
-   [ ] Refractoring
-   [ ] Performance improvement
-   [ ] Scaffolding

# How to test

```bash
bash -c "$(curl -fsSL https://deploy-preview-8--spawn-react-app.netlify.app/run.sh)" -- https://deploy-preview-8--spawn-react-app.netlify.app/spawn-react-app.tgz
```
